### PR TITLE
feat(dsoc): complete proposal portal end-to-end

### DIFF
--- a/app/api/dsoc/applications/route.ts
+++ b/app/api/dsoc/applications/route.ts
@@ -43,7 +43,14 @@ export async function GET(request: NextRequest) {
     const mentorOnly = searchParams.get('mentor') === 'true';
     const menteeOnly = searchParams.get('my') === 'true';
     const menteeId = menteeOnly ? await getMenteeFromToken(request) : null;
-    
+
+    if (menteeOnly && !menteeId) {
+      return NextResponse.json(
+        { success: false, error: 'Unauthorized' },
+        { status: 401 }
+      );
+    }
+
     const query: any = {};
 
     if (mentorOnly) {
@@ -111,6 +118,14 @@ export async function POST(request: NextRequest) {
     
     const body = await request.json();
     const { projectId, ...applicationData } = body;
+
+    // Drop empty-string optional fields so mongoose doesn't try to cast them
+    // (empty string into a Date field throws CastError).
+    Object.keys(applicationData).forEach((key) => {
+      if (applicationData[key] === '' || applicationData[key] === null) {
+        delete applicationData[key];
+      }
+    });
     
     // Check if project exists and is open
     const project = await DSOCProject.findById(projectId);

--- a/app/dsoc/mentee/dashboard/page.tsx
+++ b/app/dsoc/mentee/dashboard/page.tsx
@@ -20,6 +20,9 @@ interface Application {
   _id: string;
   status: string;
   createdAt: string;
+  mentorNotes?: string;
+  score?: number;
+  reviewedAt?: string;
   project: {
     _id: string;
     title: string;
@@ -201,32 +204,63 @@ export default function MenteeDashboard() {
                 </Link>
               </div>
             ) : (
-              applications.map((app) => (
-                <div key={app._id} className="neo-brutal-card p-6">
-                  <div className="flex items-start justify-between gap-4">
-                    <div className="flex-1">
-                      <div className="flex items-center gap-3 mb-2">
-                        {getStatusIcon(app.status)}
-                        <span className={`neo-brutal-badge text-xs text-white ${getStatusColor(app.status)}`}>
-                          {app.status.replace('-', ' ')}
-                        </span>
+              applications.map((app) => {
+                const hasFeedback =
+                  (app.status === 'accepted' ||
+                    app.status === 'rejected' ||
+                    app.status === 'waitlisted' ||
+                    app.status === 'under-review') &&
+                  (app.mentorNotes || typeof app.score === 'number');
+
+                return (
+                  <div key={app._id} className="neo-brutal-card p-6">
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="flex-1">
+                        <div className="flex items-center gap-3 mb-2">
+                          {getStatusIcon(app.status)}
+                          <span className={`neo-brutal-badge text-xs text-white ${getStatusColor(app.status)}`}>
+                            {app.status.replace('-', ' ')}
+                          </span>
+                          {typeof app.score === 'number' && (
+                            <span className="neo-brutal-badge text-xs bg-[var(--dsoc-purple)] text-white">
+                              Score: {app.score}/100
+                            </span>
+                          )}
+                        </div>
+                        <h3 className="text-xl font-bold">{app.project.title}</h3>
+                        <p className="text-muted-foreground">{app.project.organization}</p>
+                        <p className="text-sm text-muted-foreground mt-2">
+                          Applied on {new Date(app.createdAt).toLocaleDateString()}
+                          {app.reviewedAt && (
+                            <>
+                              {' • Reviewed '}
+                              {new Date(app.reviewedAt).toLocaleDateString()}
+                            </>
+                          )}
+                        </p>
                       </div>
-                      <h3 className="text-xl font-bold">{app.project.title}</h3>
-                      <p className="text-muted-foreground">{app.project.organization}</p>
-                      <p className="text-sm text-muted-foreground mt-2">
-                        Applied on {new Date(app.createdAt).toLocaleDateString()}
-                      </p>
+                      <Link
+                        href={`/dsoc/projects/${app.project._id}`}
+                        className="neo-brutal-btn neo-brutal-btn-secondary py-2 px-4 text-sm"
+                      >
+                        <ExternalLink className="w-4 h-4 mr-2" />
+                        View Project
+                      </Link>
                     </div>
-                    <Link 
-                      href={`/dsoc/projects/${app.project._id}`}
-                      className="neo-brutal-btn neo-brutal-btn-secondary py-2 px-4 text-sm"
-                    >
-                      <ExternalLink className="w-4 h-4 mr-2" />
-                      View Project
-                    </Link>
+
+                    {hasFeedback && app.mentorNotes && (
+                      <div className="mt-4 p-4 bg-[var(--dsoc-light)] border-4 border-[var(--dsoc-dark)]">
+                        <div className="text-xs font-black uppercase tracking-wider text-muted-foreground mb-2">
+                          Mentor Feedback
+                        </div>
+                        <p className="text-sm whitespace-pre-wrap leading-relaxed">
+                          {app.mentorNotes}
+                        </p>
+                      </div>
+                    )}
                   </div>
-                </div>
-              ))
+                );
+              })
             )}
           </div>
         )}

--- a/models/DSOCApplication.ts
+++ b/models/DSOCApplication.ts
@@ -6,12 +6,19 @@ export interface IDSOCApplication extends Document {
   discordUsername: string;
   proposal: string;
   coverLetter?: string;
-  relevantExperience: string;
   whyThisProject: string;
-  availability: string;
-  expectedLearnings: string;
+  motivation?: string;
+  relevantExperience: string;
+  technicalSkills?: string;
+  githubProfile?: string;
   portfolioLinks: string[];
   previousContributions?: string;
+  timeline?: string;
+  expectedLearnings: string;
+  challenges?: string;
+  availability: string;
+  timezone?: string;
+  startDate?: Date;
   status: 'pending' | 'under-review' | 'accepted' | 'rejected' | 'waitlisted' | 'withdrawn';
   mentorNotes?: string;
   adminNotes?: string;
@@ -48,24 +55,26 @@ const DSOCApplicationSchema = new Schema<IDSOCApplication>(
       type: String,
       trim: true,
     },
-    relevantExperience: {
-      type: String,
-      required: [true, 'Relevant experience is required'],
-      trim: true,
-    },
     whyThisProject: {
       type: String,
       required: [true, 'Why this project answer is required'],
       trim: true,
     },
-    availability: {
+    motivation: {
       type: String,
-      required: [true, 'Availability is required'],
       trim: true,
     },
-    expectedLearnings: {
+    relevantExperience: {
       type: String,
-      required: [true, 'Expected learnings is required'],
+      required: [true, 'Relevant experience is required'],
+      trim: true,
+    },
+    technicalSkills: {
+      type: String,
+      trim: true,
+    },
+    githubProfile: {
+      type: String,
       trim: true,
     },
     portfolioLinks: [{
@@ -75,6 +84,31 @@ const DSOCApplicationSchema = new Schema<IDSOCApplication>(
     previousContributions: {
       type: String,
       trim: true,
+    },
+    timeline: {
+      type: String,
+      trim: true,
+    },
+    expectedLearnings: {
+      type: String,
+      required: [true, 'Expected learnings is required'],
+      trim: true,
+    },
+    challenges: {
+      type: String,
+      trim: true,
+    },
+    availability: {
+      type: String,
+      required: [true, 'Availability is required'],
+      trim: true,
+    },
+    timezone: {
+      type: String,
+      trim: true,
+    },
+    startDate: {
+      type: Date,
     },
     status: {
       type: String,


### PR DESCRIPTION
## Summary

Closes the loop on the DSOC proposal flow. Before this PR, the apply form posted fields that mongoose silently dropped, the mentor dashboard linked to a 404, and mentees never saw any feedback after their application was reviewed.

- **Mentor review page** at `/dsoc/applications/[id]` — full proposal, applicant context, status update, score, notes, accept/reject actions. The mentor dashboard already links here.
- **Schema completeness** — `DSOCApplication` now persists `motivation`, `technicalSkills`, `githubProfile`, `timeline`, `challenges`, `timezone`, `startDate`. These were posted by the apply form but dropped by mongoose strict mode.
- **POST sanitisation** — empty optional strings (notably `startDate`) are dropped before save so the Date cast doesn't throw.
- **Mentee feedback loop** — mentee dashboard surfaces `mentorNotes`, `score`, and review date inline once a proposal has been reviewed.
- **Security fix** — `GET /api/dsoc/applications?my=true` with no mentee session was returning every application in the database. Now requires auth.

## Roles after this change

- **Students** submit a proposal via `/dsoc/apply/[id]`, see status + feedback on `/dsoc/mentee/dashboard`.
- **Mentors** review proposals for their assigned projects on `/dsoc/mentor/dashboard` and open the full proposal at `/dsoc/applications/[id]` to set status, score, and notes.
- **Admins** can review any application at the same URL (existing admin-token auth path).

## Test plan

- [ ] Mentor logs in, opens dashboard, clicks Review on a pending application, sets status + score + notes, saves
- [ ] Same proposal now shows the new status + mentor feedback on the mentee dashboard
- [ ] Apply form submits with optional fields blank (startDate, etc.) without server error
- [ ] Calling `/api/dsoc/applications?my=true` without a mentee cookie returns 401, not data
- [ ] Mentor B (not assigned to the project) cannot open another mentor's application — still 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)