### PR TITLE
docs: add "Choosing the Right Project to Build" guide

### DIFF
--- a/content/guides/choosing-the-right-project.md
+++ b/content/guides/choosing-the-right-project.md
@@ -1,0 +1,64 @@
+---
+title: "Choosing the Right Project to Build"
+description: "A practical framework for picking a project that actually teaches you something, pushes you technically, and gets real users."
+category: "Projects & Building"
+featured: true
+order: 1
+date: "2026-08-12"
+author: "Midhat Kazmi"
+icon: "Compass"
+readingTime: "8 min read"
+image: "/guides/project-selection-framework.svg"
+---
+
+Every year, hundreds of students sit down to pick a "project" and end up building the same to-do app, the same weather dashboard, the same clone of something that already exists. Six months later they have a GitHub repo with zero stars, zero users, and nothing to talk about in an interview. Picking the right project is arguably more important than how well you execute it, because the right project pulls hard work out of you naturally, and the wrong one makes even small tasks feel like a grind.
+
+## 1. Pick for Depth, Not Novelty
+
+Why does technical depth matter more than a "cool" idea?
+
+A project idea is only as good as what it forces you to learn. Before committing, ask yourself, if I actually built this end-to-end, what would I be forced to understand that I don't understand today? Good answers sound like "how large-scale systems handle state," "how to orchestrate infrastructure at scale," "how audio or video generation actually works under the hood," or "how operating systems manage resources when things get complicated."
+
+A useful gut check: could this project reasonably take 4 to 6 months to build properly while you're learning as you go? If you can fully picture the finished product on day one, it's probably not deep enough. Projects worth doing usually involve some combination of:
+
+1. Systems and infrastructure work,clusters, queues, distributed state, scheduling
+2. Emerging technical areas,fine-tuning models, generative audio/video, agent orchestration, platform engineering
+3. Real engineering trade-offs, not just gluing together existing APIs
+
+And a rule worth repeating to yourself often, the project should use AI, not be AI. If you strip out the AI-powered feature and the remaining system doesn't hold any real engineering weight, you haven't picked a project, you've picked a wrapper.
+
+## 2. Build in a Team, Not Alone
+
+Why is working solo often the wrong call?
+
+The strongest projects rarely come out of one person coding in isolation for months. Small teams, two or three people, ideally mixing seniors and juniors consistently produce better outcomes because they force you to actually design before you build, split real-world systems into real-world components, and defend your decisions to someone else. Juniors get direct exposure to how experienced engineers think, and seniors get pushed to explain their reasoning instead of just knowing it instinctively.
+
+If you're picking a project for a fellowship, capstone, or FYP, treat it the same way you'd treat a startup: gather a short list of ideas, then let people apply to work on them with a clear statement of intent, some early research, and realistic availability. Strong intent up front saves everyone months of misaligned effort later.
+
+## 3. Design for Users From Day One
+
+Why should adoption be a first-class requirement, not an afterthought?
+
+This is the pillar most students skip, and it's the one that separates a portfolio piece from a real project. A system with brilliant architecture and zero users doesn't feel like a good project,not to you, not to an interviewer, not to anyone evaluating it later. Before you write a line of code, have an honest answer to: who is going to use this, and how are they going to find out it exists?
+
+## Projects that pass this test tend to fall into a few recognizable shapes:
+
+Platforms with a built-in feedback loop,a course platform with in-browser code execution and testing, for example, forces you to think about grading pipelines, sandboxed execution, and scale from day one.
+Infrastructure-heavy automation tools, systems that run headless agents or browser automation in the cloud, dispatch scheduled work, and let a user control something remotely, teach you real distributed systems thinking.
+"Meta" products on top of existing software, tools that pull together insights across many other tools or services (free or paid) into one smarter surface. The hard part of software today usually isn't the implementation, it's getting people to adopt and pay for it,a project that tackles that head on has real depth baked in.
+Personalized content or wellness tools,systems that combine a large, constantly growing dataset with fine tuned models to filter, personalize, or surface content for a specific community's needs. These look simple on the surface but hide serious data and ML engineering underneath.
+
+None of these need to be copied exactly, the point is the shape: pick something with enough surface area that "getting people to actually use it" becomes part of the engineering problem, not a footnote after you're done.
+
+## Putting it together
+
+Before you commit to a project, run it through all three filters honestly:
+
+Will this force me to learn something I don't already know, for 4-6 months straight?
+Am I building this with the right mix of people, not just by myself?
+Have I designed a real path to actual users, not just a demo?
+
+If you can say yes to all three, you're not just picking a project, you're setting yourself up to walk into a conference or an interview with a system you can talk about for an hour, built by a team, used by real people.
+
+_Midhat Kazmi_
+_Dev Weekends_

--- a/content/guides/choosing-the-right-project.md
+++ b/content/guides/choosing-the-right-project.md
@@ -7,7 +7,7 @@ order: 1
 date: "2026-08-12"
 author: "Midhat Kazmi"
 icon: "Compass"
-readingTime: "8 min read"
+readingTime: "9 min read"
 image: "/guides/project-selection-framework.svg"
 ---
 
@@ -49,6 +49,17 @@ Infrastructure-heavy automation tools, systems that run headless agents or brows
 Personalized content or wellness tools,systems that combine a large, constantly growing dataset with fine tuned models to filter, personalize, or surface content for a specific community's needs. These look simple on the surface but hide serious data and ML engineering underneath.
 
 None of these need to be copied exactly, the point is the shape: pick something with enough surface area that "getting people to actually use it" becomes part of the engineering problem, not a footnote after you're done.
+
+
+## Where it's actually easier to get users
+
+Adoption difficulty is not the same for every kind of project, and it's worth thinking about before you commit, not after you've already built the thing and are wondering why nobody signed up.
+
+1. Two-sided marketplaces are one of the hardest patterns to get real users for. Anything shaped like Uber, where you need two different types of users, a service provider and a service receiver, to both show up at the same time for the product to have any value, runs into the classic chicken-and-egg problem. Riders won't open the app if there are no drivers nearby, and drivers won't sign up if there are no riders to pick up. This is solvable, but it usually takes serious capital, a specific city or niche to seed first, and a lot of manual, unscalable work in the early days, none of which fits a 4 to 6 month student project. Avoid this shape unless user acquisition itself is the thing you're trying to learn.
+
+2. Government and large institutional systems, think a government portal or a full university management system, are hard for a different reason. The engineering can be genuinely deep, but deployment depends on procurement processes, approvals, and politics that are completely outside your control. You can build something excellent and still have it sit unused because the actual decision makers never adopted it. If you're drawn to this space, it's usually smarter to build a smaller tool aimed at a specific department or a specific pain point, something a few real people can start using on their own, rather than the full official system that needs institutional buy-in to go anywhere.
+
+The easiest projects to get real users for are ones where a single, well-defined type of user can get value from day one without needing anyone else to also adopt it at the same time, students, developers, a specific hobbyist community, people already active in an online community you have access to. If you can picture yourself getting 10 real people to try it in the first week just by asking around, that's usually a strong signal you picked a shape with a realistic path to adoption.
 
 ## Putting it together
 

--- a/public/guides/project-selection-framework.svg
+++ b/public/guides/project-selection-framework.svg
@@ -1,0 +1,41 @@
+<svg width="100%" viewBox="0 0 680 320" xmlns="http://www.w3.org/2000/svg" role="img">
+  <title>Three pillars of choosing a project: depth, team, and users</title>
+  <desc>A diagram showing three connected pillars — technical depth, team, and users — that together make a project worth building.</desc>
+
+  <rect x="0" y="0" width="680" height="320" fill="none"/>
+
+  <line x1="150" y1="150" x2="340" y2="150" stroke="#22C55E" stroke-width="1.5" opacity="0.5"/>
+  <line x1="340" y1="150" x2="530" y2="150" stroke="#22C55E" stroke-width="1.5" opacity="0.5"/>
+
+  <g>
+    <rect x="70" y="80" width="160" height="140" rx="12" fill="#22C55E" fill-opacity="0.08" stroke="#16A34A" stroke-width="1"/>
+    <circle cx="150" cy="130" r="20" fill="#22C55E" fill-opacity="0.18"/>
+    <path d="M150 118 L150 142 M138 130 L162 130" stroke="#16A34A" stroke-width="2.5" stroke-linecap="round"/>
+    <text x="150" y="172" text-anchor="middle" font-family="sans-serif" font-size="15" font-weight="600" fill="#16A34A">Depth</text>
+    <text x="150" y="194" text-anchor="middle" font-family="sans-serif" font-size="12" fill="#16A34A" opacity="0.8">4-6 months of</text>
+    <text x="150" y="210" text-anchor="middle" font-family="sans-serif" font-size="12" fill="#16A34A" opacity="0.8">real learning</text>
+  </g>
+
+  <g>
+    <rect x="260" y="80" width="160" height="140" rx="12" fill="#22C55E" fill-opacity="0.08" stroke="#16A34A" stroke-width="1"/>
+    <circle cx="325" cy="128" r="10" fill="#22C55E" fill-opacity="0.25"/>
+    <circle cx="355" cy="128" r="10" fill="#22C55E" fill-opacity="0.25"/>
+    <circle cx="340" cy="112" r="10" fill="#22C55E" fill-opacity="0.35"/>
+    <text x="340" y="172" text-anchor="middle" font-family="sans-serif" font-size="15" font-weight="600" fill="#16A34A">Team</text>
+    <text x="340" y="194" text-anchor="middle" font-family="sans-serif" font-size="12" fill="#16A34A" opacity="0.8">Seniors and</text>
+    <text x="340" y="210" text-anchor="middle" font-family="sans-serif" font-size="12" fill="#16A34A" opacity="0.8">juniors, together</text>
+  </g>
+
+  <g>
+    <rect x="450" y="80" width="160" height="140" rx="12" fill="#22C55E" fill-opacity="0.08" stroke="#16A34A" stroke-width="1"/>
+    <circle cx="530" cy="125" r="18" fill="#22C55E" fill-opacity="0.18"/>
+    <circle cx="518" cy="120" r="4" fill="#16A34A"/>
+    <circle cx="530" cy="115" r="4" fill="#16A34A"/>
+    <circle cx="542" cy="120" r="4" fill="#16A34A"/>
+    <text x="530" y="172" text-anchor="middle" font-family="sans-serif" font-size="15" font-weight="600" fill="#16A34A">Users</text>
+    <text x="530" y="194" text-anchor="middle" font-family="sans-serif" font-size="12" fill="#16A34A" opacity="0.8">Real adoption,</text>
+    <text x="530" y="210" text-anchor="middle" font-family="sans-serif" font-size="12" fill="#16A34A" opacity="0.8">not just a demo</text>
+  </g>
+
+  <text x="340" y="270" text-anchor="middle" font-family="sans-serif" font-size="13" fill="#6b7280">A project worth building needs all three</text>
+</svg>


### PR DESCRIPTION
Adds a new guide covering how to choose a right project, technical depth, team structure, and designing for real user

- content/guides/choosing-the-right-project.md
- public/guides/project-selection-framework.svg